### PR TITLE
move babel-core to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,9 @@
     "url": "https://github.com/mhelvens/graph.js/issues"
   },
   "license": "MIT",
-  "dependencies": {
-    "babel-core": "~5"
-  },
   "devDependencies": {
     "babel": "~5",
+    "babel-core": "~5",
     "babel-loader": "~5",
     "bower": "~1",
     "isparta": "~2",


### PR DESCRIPTION
This addresses #18 by moving `babel-core` into the `devDependencies` of this package.

It doesn't appear like this module needs to be a plain `dependency`, but a security
vulnerability in the v5 line of babel is appearing upstream as a result.